### PR TITLE
fix release json

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,7 @@
 ---
 ---
 {%- comment -%}Assign the latest post to a variable for easier access{%- endcomment -%}
-{%- assign latest_post = site.posts.first -%}
+{%- assign latest_post = (site.posts | where: "type", "release").first -%}
 
 {%- comment -%}Check if there are any posts to avoid errors{%- endcomment -%}
 {%- if latest_post -%}


### PR DESCRIPTION
This pull request updates the logic for assigning the latest post in the `releases.json` file to ensure it specifically selects posts of type "release."

Change details:

* Modified the assignment of `latest_post` to filter posts by the "release" type using the `where` filter, ensuring only release-type posts are considered. (`[releases.jsonL4-R4](diffhunk://#diff-f71e67b61c52ecd942c6d915f8ff111cb57052fe82992eda958b87a9c62ed633L4-R4)`)