### PR TITLE
Dev

### DIFF
--- a/_site/releases.json
+++ b/_site/releases.json
@@ -1,6 +1,6 @@
 {
   "latest": {
-    "version": "N/A",
-    "date": "2025-04-19","notes": "Struggling to stick with a budget? Here are 5 simple, effective ways to build a lasting budgeting habit using Astreos—starting with your next paycheck.","url": null,"releaseNotes": "http://localhost:4000/budgeting/habits/getting-started/2025/04/19/start-budgeting-habit.html"
+    "version": "0.6.1",
+    "date": "2025-04-19","notes": "Patches an issue where Astreos would load with a blank page.","url": null,"releaseNotes": "http://localhost:4000/2025/04/19/astreos-v0.6.1.html"
   }
 }

--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,8 @@
 ---
 ---
 {%- comment -%}Assign the latest post to a variable for easier access{%- endcomment -%}
-{%- assign latest_post = (site.posts | where: "type", "release").first -%}
+{%- assign release_posts = site.posts | where_exp: "item", "item.type == 'release'" -%}
+{%- assign latest_post = release_posts | sort: 'date' | last -%}
 
 {%- comment -%}Check if there are any posts to avoid errors{%- endcomment -%}
 {%- if latest_post -%}


### PR DESCRIPTION
This pull request updates the release information and improves the logic for determining the latest release post. The changes ensure more accurate and maintainable handling of release data.

### Updates to release information:

* [`_site/releases.json`](diffhunk://#diff-c54cbd432db8aaed7f6d2d5c7aa8556dee6f1ca7d8d3d3f777dd0909e15022ccL3-R4): Updated the "latest" release information to reflect version `0.6.1`, including a new release date, notes about a patched issue, and an updated link to the release notes.

### Improvements to release post logic:

* [`releases.json`](diffhunk://#diff-f71e67b61c52ecd942c6d915f8ff111cb57052fe82992eda958b87a9c62ed633L4-R5): Changed the logic for assigning the latest release post by filtering posts with `type == 'release'` and sorting them by date, ensuring the correct post is selected as the latest release.